### PR TITLE
ref:misc: XPLAT I : Cross-platform part 1

### DIFF
--- a/action_unit.pas
+++ b/action_unit.pas
@@ -30,7 +30,7 @@ unit action_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls;
 
 type

--- a/bgkeeps_unit.pas
+++ b/bgkeeps_unit.pas
@@ -30,7 +30,7 @@ unit bgkeeps_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls;
 
 type

--- a/calibration_unit.pas
+++ b/calibration_unit.pas
@@ -32,9 +32,8 @@ unit calibration_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
-  StdCtrls, ExtCtrls
-  , LCLtype;     // OT-FIRST
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  StdCtrls, ExtCtrls;
 
 type
   Tcalibration_form = class(TForm)

--- a/chat_unit.pas
+++ b/chat_unit.pas
@@ -30,7 +30,7 @@ unit chat_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ComCtrls, ExtCtrls, PrintersDlgs;
 
 type

--- a/check_diffs_unit.pas
+++ b/check_diffs_unit.pas
@@ -30,7 +30,7 @@ unit check_diffs_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, Buttons, ExtCtrls, ComCtrls;
 
 type

--- a/create_tandem.pas
+++ b/create_tandem.pas
@@ -30,7 +30,7 @@ unit create_tandem;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, Math;
 
 type

--- a/data_memo_unit.pas
+++ b/data_memo_unit.pas
@@ -30,7 +30,7 @@ unit data_memo_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs, Clipbrd,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs, Clipbrd,
   control_room, math_unit,
   StdCtrls;
 

--- a/dxf_unit.pas
+++ b/dxf_unit.pas
@@ -30,7 +30,7 @@ unit dxf_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls;
 
 type

--- a/edit_memo_unit.pas
+++ b/edit_memo_unit.pas
@@ -30,7 +30,7 @@ unit edit_memo_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls;
 
 type

--- a/gauge_unit.pas
+++ b/gauge_unit.pas
@@ -30,7 +30,7 @@ unit gauge_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls
   , LCLtype;     // OT-FIRST
 

--- a/math2_unit.pas
+++ b/math2_unit.pas
@@ -30,7 +30,7 @@ unit math2_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls, MaskEdit, FileCtrl, Math,
   pad_unit;      //  need Tpex declaration in this part for parameters to routines.
 

--- a/mecbox_unit.pas
+++ b/mecbox_unit.pas
@@ -31,7 +31,7 @@ unit mecbox_unit;          // 290a  file transfers via MECBOX text-based format
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs;
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs;
 
 type
   Tmecbox_form = class(TForm)

--- a/metric_unit.pas
+++ b/metric_unit.pas
@@ -30,7 +30,7 @@ unit metric_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, Spin, ComCtrls { OT-FIRST , ReadHTML, framview};
 
 type

--- a/mint_unit.pas
+++ b/mint_unit.pas
@@ -30,7 +30,7 @@ unit mint_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls, Htmlview, Grids, Outline{, DirOutln}, HtmlGlobals;
 
 type

--- a/model/background_shapes.pas
+++ b/model/background_shapes.pas
@@ -33,7 +33,7 @@ unit background_shapes;
 interface
 
 uses
-  Windows,
+  LCLType,
   Classes,
   SysUtils,
   Graphics,

--- a/panning_unit.pas
+++ b/panning_unit.pas
@@ -30,7 +30,7 @@ unit panning_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   ExtCtrls, ComCtrls, StdCtrls, Buttons;
 
 type

--- a/plain_track_unit.pas
+++ b/plain_track_unit.pas
@@ -30,7 +30,7 @@ unit plain_track_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   ExtCtrls, ComCtrls, StdCtrls;
 
 type

--- a/platform_unit.pas
+++ b/platform_unit.pas
@@ -30,7 +30,7 @@ unit platform_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls;
 
 type

--- a/prefs_unit.pas
+++ b/prefs_unit.pas
@@ -31,7 +31,7 @@ unit prefs_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs, Clipbrd,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs, Clipbrd,
   StdCtrls, FileCtrl;
 
 type

--- a/preview_unit.pas
+++ b/preview_unit.pas
@@ -30,7 +30,7 @@ unit preview_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls,
   point_ex;  // needs to be here for Tpex
 

--- a/print_now_box.pas
+++ b/print_now_box.pas
@@ -30,7 +30,7 @@ unit print_now_box;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls;
 
 type

--- a/print_unit.pas
+++ b/print_unit.pas
@@ -30,7 +30,7 @@ unit print_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls
 
   { OT-FIRST ,dtpShape,dtpGR32};  // 206e

--- a/rail_options_unit.pas
+++ b/rail_options_unit.pas
@@ -30,7 +30,7 @@ unit rail_options_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls;
 
 type

--- a/stay_visible_unit.pas
+++ b/stay_visible_unit.pas
@@ -30,7 +30,7 @@ unit stay_visible_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   ExtCtrls, ComCtrls, StdCtrls;
 
 type

--- a/templotmec.lpr
+++ b/templotmec.lpr
@@ -31,7 +31,7 @@ uses
 
            // Lazarus units:
 
-  Forms, Interfaces, SysUtils, Dialogs, ShellAPI, FileUtil, Classes,
+  Forms, Interfaces, SysUtils, Dialogs, FileUtil, Classes,
 
 
            // Templot3 units:

--- a/trackbed_unit.pas
+++ b/trackbed_unit.pas
@@ -30,7 +30,7 @@ unit trackbed_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ComCtrls, ExtCtrls;
 
 type

--- a/wait_message.pas
+++ b/wait_message.pas
@@ -30,7 +30,7 @@ unit wait_message;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls;
 
 type

--- a/web_map_help_unit.pas
+++ b/web_map_help_unit.pas
@@ -30,7 +30,7 @@ unit web_map_help_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   Htmlview, StdCtrls, ExtCtrls, HtmlGlobals;
 
 type

--- a/xing_select.pas
+++ b/xing_select.pas
@@ -30,7 +30,7 @@ unit xing_select;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  LCLType, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls, ExtCtrls, ComCtrls;
 
 type

--- a/xtc_unit.pas
+++ b/xtc_unit.pas
@@ -32,7 +32,7 @@ unit xtc_unit;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
+  Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs,
   StdCtrls;
 
 type


### PR DESCRIPTION
Remove 'use's of 'Windows' where it is redundant or can be replaced
by LCLType