### PR TITLE
ref:doc: Rename the project jcfsettings.cfg and update the instructions for use

### DIFF
--- a/OT-jcfsettings.cfg
+++ b/OT-jcfsettings.cfg
@@ -2,7 +2,7 @@
 <JediCodeFormatSettings>
     <WriteVersion> 2.44 </WriteVersion>
     <WriteDateTime> 44452.4383224074 </WriteDateTime>
-    <Description> format settings for use with Lazarus </Description>
+    <Description> Lazarus settings for ** openTemplot ** </Description>
     <ConfirmFormat> True </ConfirmFormat>
   <Obfuscate>
       <Enabled> False </Enabled>

--- a/docs/developers_guide.adoc
+++ b/docs/developers_guide.adoc
@@ -35,9 +35,10 @@ To (slightly mis-)quote the Go-lang community, the format is nobody's favourite,
 but everyone loves the fact that it exists.
 
 In order to configure JEDI the settings file you need is provided in 
-the project's root directory (jcfsettings.cfg). To make use of this file, you need
-to copy it into the appropriate directory. This again varies by platform. You can
-find where it lives on your system by opening Lazarus and using the menu
+the project's root directory (OT-jcfsettings.cfg). To make use of this file, you need
+to copy it into the appropriate directory as jcfsettings.cfg. This directory again
+varies by platform. You can find where it lives on your system by 
+opening Lazarus and using the menu
 
      Source -> JEDI Code Format -> Format Settings
 


### PR DESCRIPTION
Add a comment to jcfsettings.cfg to make it clear we are using the
right version of the file.