### PR TITLE
ref:misc: Remove calculations for Mark Codes

### DIFF
--- a/dxf_unit.pas
+++ b/dxf_unit.pas
@@ -703,8 +703,8 @@ var
 
       if (_3d = False)
         or ((code <> eMC_3_TimberOutline)
-        and (code <> eMC_33_ShovingTimberOutline)
-        and (code <> eMC_93_ShovedTimberInfill))
+        and (code <> eMC_33_SelectedTimberOutline)
+        and (code <> eMC_93_ShovedTimberOutline))
       // not 3-D timber edges.
       then begin
         x1 := move_to.x / 100;
@@ -983,14 +983,14 @@ begin
             layer := 7;    // radial end marks.  transition marks.
 
           eMC_3_TimberOutline,
-          eMC_33_ShovingTimberOutline,
-          eMC_93_ShovedTimberInfill:
+          eMC_33_SelectedTimberOutline,
+          eMC_93_ShovedTimberOutline:
             layer := 3;    // timber outlines.
 
           eMC_4_TimberCL,
-          eMC_14_TimberCLSolid,
-          eMC_44_ShovingTimberCL_1,
-          eMC_54_ShovingTimberCL_2: begin
+          eMC_14_TimberCLMidline,
+          eMC_44_ShovingTimberCL,
+          eMC_54_ShovingTimberCLMidline: begin
             if _3d = True then
               CONTINUE
             else

--- a/export_draw_unit.pas
+++ b/export_draw_unit.pas
@@ -418,12 +418,12 @@ var
             eMC_3_TimberOutline,
             eMC_4_TimberCL,
             eMC_5_TimberReducedEnd,
-            eMC_14_TimberCLSolid,
-            eMC_33_ShovingTimberOutline,
-            eMC_44_ShovingTimberCL_1,
-            eMC_54_ShovingTimberCL_2,
+            eMC_14_TimberCLMidline,
+            eMC_33_SelectedTimberOutline,
+            eMC_44_ShovingTimberCL,
+            eMC_54_ShovingTimberCLMidline,
             eMC_55_ReducedEnd,
-            eMC_93_ShovedTimberInfill,
+            eMC_93_ShovedTimberOutline,
             eMC_95_ReducedEndInfill,
             eMC_99_TimberNumber,
             eMC_203_TimberInfill,
@@ -437,9 +437,9 @@ var
         then begin
           case mark_code of
             eMC_4_TimberCL,
-            eMC_14_TimberCLSolid,
-            eMC_44_ShovingTimberCL_1,
-            eMC_54_ShovingTimberCL_2:
+            eMC_14_TimberCLMidline,
+            eMC_44_ShovingTimberCL,
+            eMC_54_ShovingTimberCLMidline:
               CONTINUE;     // timber centre-lines not wanted.
           end;//case
         end;
@@ -527,8 +527,8 @@ var
                 eMC_2_RadialEnd:
                   Pen.Color := printalign_colour;  // rad end marks.
                 eMC_3_TimberOutline,
-                eMC_33_ShovingTimberOutline,
-                eMC_93_ShovedTimberInfill:
+                eMC_33_SelectedTimberOutline,
+                eMC_93_ShovedTimberOutline:
                   Pen.Color := printtimber_colour; // timber outlines.
                 eMC_6_RailJoint:
                   Pen.Color := printjoint_colour;  // rail joint marks.
@@ -549,12 +549,12 @@ var
               eMC_2_RadialEnd:
                 Pen.Width := printmark_wide;    // rad end marks.
               eMC_3_TimberOutline,
-              eMC_33_ShovingTimberOutline,
-              eMC_93_ShovedTimberInfill:
+              eMC_33_SelectedTimberOutline,
+              eMC_93_ShovedTimberOutline:
                 Pen.Width := printtimber_wide;  // timber outlines.
 
               eMC_4_TimberCL,
-              eMC_44_ShovingTimberCL_1:
+              eMC_44_ShovingTimberCL:
                 Pen.Style := psDash;    // timber centre-lines.
 
               eMC_5_TimberReducedEnd,
@@ -567,8 +567,8 @@ var
               eMC_7_TransitionAndSlewing:
                 Pen.Width := printmark_wide;    // transition ends.
 
-              eMC_14_TimberCLSolid,
-              eMC_54_ShovingTimberCL_2:
+              eMC_14_TimberCLMidline,
+              eMC_54_ShovingTimberCLMidline:
                 Pen.Width := printrail_wide;
                 // timber centre-lines with rail centre-lines (for rivet locations?).
 
@@ -2456,12 +2456,12 @@ begin
               eMC_3_TimberOutline,
               eMC_4_TimberCL,
               eMC_5_TimberReducedEnd,
-              eMC_14_TimberCLSolid,
-              eMC_33_ShovingTimberOutline,
-              eMC_44_ShovingTimberCL_1,
-              eMC_54_ShovingTimberCL_2,
+              eMC_14_TimberCLMidline,
+              eMC_33_SelectedTimberOutline,
+              eMC_44_ShovingTimberCL,
+              eMC_54_ShovingTimberCLMidline,
               eMC_55_ReducedEnd,
-              eMC_93_ShovedTimberInfill,
+              eMC_93_ShovedTimberOutline,
               eMC_95_ReducedEndInfill,
               eMC_99_TimberNumber,
               eMC_203_TimberInfill,
@@ -2475,9 +2475,9 @@ begin
           then begin
             case code of
               eMC_4_TimberCL,
-              eMC_14_TimberCLSolid,
-              eMC_44_ShovingTimberCL_1,
-              eMC_54_ShovingTimberCL_2:
+              eMC_14_TimberCLMidline,
+              eMC_44_ShovingTimberCL,
+              eMC_54_ShovingTimberCLMidline:
                 CONTINUE;     // timber centre-lines not wanted.
             end;//case
           end;
@@ -2566,11 +2566,11 @@ begin
               eMC_2_RadialEnd:
                 Pen.Width := printmark_wide;    // rad end marks.
               eMC_3_TimberOutline,
-              eMC_33_ShovingTimberOutline,
-              eMC_93_ShovedTimberInfill:
+              eMC_33_SelectedTimberOutline,
+              eMC_93_ShovedTimberOutline:
                 Pen.Width := printtimber_wide;  // timber outlines.
               eMC_4_TimberCL,
-              eMC_44_ShovingTimberCL_1:
+              eMC_44_ShovingTimberCL:
                 Pen.Width := 1;                  // timber centre-lines.
               eMC_5_TimberReducedEnd,
               eMC_55_ReducedEnd,
@@ -2580,8 +2580,8 @@ begin
                 Pen.Width := printmark_wide;    // rail joint marks.
               eMC_7_TransitionAndSlewing:
                 Pen.Width := printmark_wide;    // transition ends.
-              eMC_14_TimberCLSolid,
-              eMC_54_ShovingTimberCL_2:
+              eMC_14_TimberCLMidline,
+              eMC_54_ShovingTimberCLMidline:
                 Pen.Width := printrail_wide;
                 // timber centre-lines with rail centre-lines (for rivet locations?).
 
@@ -2596,7 +2596,7 @@ begin
 
             case code of
               eMC_4_TimberCL,
-              eMC_44_ShovingTimberCL_1:
+              eMC_44_ShovingTimberCL:
                 Pen.Style := psDash;    // timber centre-lines (not for rivets).
               eMC_5_TimberReducedEnd,
               eMC_55_ReducedEnd,
@@ -2629,8 +2629,8 @@ begin
                     eMC_2_RadialEnd:
                       Pen.Color := printalign_colour;  // rad end marks.
                     eMC_3_TimberOutline,
-                    eMC_33_ShovingTimberOutline,
-                    eMC_93_ShovedTimberInfill:
+                    eMC_33_SelectedTimberOutline,
+                    eMC_93_ShovedTimberOutline:
                       Pen.Color := printtimber_colour; // timber outlines.
                     eMC_6_RailJoint:
                       Pen.Color := printjoint_colour;  // rail joints.

--- a/grid_unit.pas
+++ b/grid_unit.pas
@@ -2012,8 +2012,8 @@ begin
                         CONTINUE;
 
                     eMC_3_TimberOutline,
-                    eMC_33_ShovingTimberOutline,
-                    eMC_93_ShovedTimberInfill:
+                    eMC_33_SelectedTimberOutline,
+                    eMC_93_ShovedTimberOutline:
                       if timber_outlines_checkbox.Checked = True then begin
                         if using_marker_colour = False then
                           Pen.Color := bgkeep_timber_colour  // timber outlines.
@@ -2024,9 +2024,9 @@ begin
                         CONTINUE;
 
                     eMC_4_TimberCL,
-                    eMC_14_TimberCLSolid,
-                    eMC_44_ShovingTimberCL_1,
-                    eMC_54_ShovingTimberCL_2:
+                    eMC_14_TimberCLMidline,
+                    eMC_44_ShovingTimberCL,
+                    eMC_54_ShovingTimberCLMidline:
                       if timber_centres_checkbox.Checked = True then begin
                         if using_marker_colour = False then
                           Pen.Color := bgkeep_timber_colour  // timber centre-lines only on pad.

--- a/keep_select.pas
+++ b/keep_select.pas
@@ -5194,17 +5194,17 @@ begin
                   CONTINUE;
 
               eMC_3_TimberOutline,
-              eMC_33_ShovingTimberOutline,
-              eMC_93_ShovedTimberInfill:
+              eMC_33_SelectedTimberOutline,
+              eMC_93_ShovedTimberOutline:
                 if timber_outlines_checkbox.Checked = True then
                   Pen.Color := box_timber_col   // timber outlines.
                 else
                   CONTINUE;
 
               eMC_4_TimberCL,
-              eMC_14_TimberCLSolid,
-              eMC_44_ShovingTimberCL_1,
-              eMC_54_ShovingTimberCL_2:
+              eMC_14_TimberCLMidline,
+              eMC_44_ShovingTimberCL,
+              eMC_54_ShovingTimberCLMidline:
                 if timber_centres_checkbox.Checked = True then
                   Pen.Color := box_timber_col   // timber centre-lines.
                 else

--- a/mark_unit.pas
+++ b/mark_unit.pas
@@ -14,15 +14,13 @@ type
   // 1. These names contain the values of the codes. This is a temporary step to help avoid
   //    mistakes as I deploy the enumeration into the code. Later, the names can be refactored
   //    to remove the values from them.
-  // 2. Also later, the values themselves can be changed, once it is confirmed that they are
-  //    transient - i.e. not written to files (which I think is true)
+  // 2. Also later, the values themselves can be changed
 
   // !!! BEWARE !!!
-  // When the time comes to allow the values to be derived by the compiler ... all sorts
-  // of shonky stuff is going on with these 'codes', including:
-  //    - dependency on the order of the values
-  //    - arithmetic performed on the codes
-  // You have been warned!
+  // The next change here is to allow the values to be derived by the compiler.
+  // This work will need to take account of the fact that there is a dependency
+  // in many places on the order of the values, namely 'case' and 'if' statements
+  // which test for ranges of values.
 
   EMarkCode = (
 
@@ -48,14 +46,19 @@ type
     eMC_10_PlainTrackStart,           // 10
     eMC_11_placeholder,               // 11 - placeholder
 
-    eMC_14_TimberCLSolid = 14,        // 14
-    eMC_33_ShovingTimberOutline = 33, // 33
-    eMC_44_ShovingTimberCL_1 = 44,    // 44
-    eMC_54_ShovingTimberCL_2 = 54,    // 54
-    eMC_55_ReducedEnd,                // 55
+    // It seems wrong that most mark codes represent what TYPE of thing is being
+    // drawn, but the following few also contain aspects of HOW it is drawn.
+    // This should be derived at the point of drawing, as for the other codes
+    // TODO: Untangle these two ideas. Move 'pen' selection to the point of drawing.
+    eMC_14_TimberCLMidline = 14,      // 14 - 'midline' = 'rails as midlines' selected
+    eMC_33_SelectedTimberOutline = 33, // 33
+    eMC_44_ShovingTimberCL = 44,      // 44 - shov'ing' implies shoved OR selected
+    eMC_54_ShovingTimberCLMidline = 54,// 54 - shov'ing' implies shoved OR selected
 
-    eMC_93_ShovedTimberInfill = 93,   // 93 - Guessed name - this value is never set
-    eMC_95_ReducedEndInfill = 95,     // 95 - Guessed name - this value is never set
+    eMC_55_ReducedEnd = 55,           // 55
+
+    eMC_93_ShovedTimberOutline = 93,  // 93
+    eMC_95_ReducedEndInfill = 95,     // 95
     eMC_98_placeholder = 98,          // 98 - placeholder
     eMC_99_TimberNumber,              // 99
 

--- a/math_unit.pas
+++ b/math_unit.pas
@@ -25326,8 +25326,13 @@ begin
            code := eMC_54_ShovingTimberCLMidline;
          eTS_Selected:
            code := eMC_54_ShovingTimberCLMidline;
-       end;
-
+       end
+    else
+       case timberStatus of
+         eTS_Normal: code := eMC_4_TimberCL;
+         eTS_Shoved: code := eMC_44_ShovingTimberCL;
+         eTS_Selected: code := eMC_44_ShovingTimberCL;
+     end;
     calc_fill_timber_mark(code);
 
   end;

--- a/math_unit.pas
+++ b/math_unit.pas
@@ -25198,8 +25198,8 @@ begin
     then begin
       if (shove_timber_form.Showing) and
         (shove_timber_form.show_all_blue_checkbox.Checked) then begin
-          timberStatus := eTS_shoved; // will be highlighted in blue or red.
-        end;
+        timberStatus := eTS_shoved; // will be highlighted in blue or red.
+      end;
       if shoved.sv_code = svcOmit     // this value in the list is a flag.
       then
         omit := True       // he wants this timber omitted.
@@ -25319,20 +25319,23 @@ begin
     y_curmod := y_curtimb - yeq;
 
     if midline then
-       case timberStatus of
-         eTS_Normal:
-           code := eMC_14_TimberCLMidline;
-         eTS_Shoved:
-           code := eMC_54_ShovingTimberCLMidline;
-         eTS_Selected:
-           code := eMC_54_ShovingTimberCLMidline;
-       end
+      case timberStatus of
+        eTS_Normal:
+          code := eMC_14_TimberCLMidline;
+        eTS_Shoved:
+          code := eMC_54_ShovingTimberCLMidline;
+        eTS_Selected:
+          code := eMC_54_ShovingTimberCLMidline;
+      end
     else
-       case timberStatus of
-         eTS_Normal: code := eMC_4_TimberCL;
-         eTS_Shoved: code := eMC_44_ShovingTimberCL;
-         eTS_Selected: code := eMC_44_ShovingTimberCL;
-     end;
+      case timberStatus of
+        eTS_Normal:
+          code := eMC_4_TimberCL;
+        eTS_Shoved:
+          code := eMC_44_ShovingTimberCL;
+        eTS_Selected:
+          code := eMC_44_ShovingTimberCL;
+      end;
     calc_fill_timber_mark(code);
 
   end;
@@ -25505,8 +25508,8 @@ begin
       if (shove_timber_form.Showing) and
         (shove_timber_form.show_all_blue_checkbox.Checked) then begin
         timberStatus := eTS_Shoved; // draw highlighted blue if required
-                                    // (may be overidden later for red if currently selected).
-        end;
+        // (may be overidden later for red if currently selected).
+      end;
       if shoved.sv_code = svcOmit                         // this value in the list is a flag.
       then
         EXIT//omit:=True              // he wants this timber omitted.
@@ -25635,9 +25638,12 @@ begin
     // Done first so outlines and reduced ends can overwrite,
     // possibly in a different colour..
     case timberStatus of
-      eTS_Normal: code := eMC_203_TimberInfill;
-      eTS_Shoved: code := eMC_293_ShovedTimberInfill;
-      eTS_Selected: code := eMC_233_ShovedTimberInfill;
+      eTS_Normal:
+        code := eMC_203_TimberInfill;
+      eTS_Shoved:
+        code := eMC_293_ShovedTimberInfill;
+      eTS_Selected:
+        code := eMC_233_ShovedTimberInfill;
     end;
 
     if timbering_infill then begin
@@ -25657,9 +25663,12 @@ begin
 
     // then timber outlines..
     case timberStatus of
-      eTS_Normal: code := eMC_3_TimberOutline;
-      eTS_Shoved: code := eMC_93_ShovedTimberOutline;
-      eTS_Selected: code := eMC_33_SelectedTimberOutline;
+      eTS_Normal:
+        code := eMC_3_TimberOutline;
+      eTS_Shoved:
+        code := eMC_93_ShovedTimberOutline;
+      eTS_Selected:
+        code := eMC_33_SelectedTimberOutline;
     end;
 
     p1.x := xns - tbl + crab;
@@ -25694,11 +25703,14 @@ begin
     if (nine_foot) and (reduced_ends)   // standard 9ft timbering..
     then begin
 
-    case timberStatus of
-      eTS_Normal: code := eMC_5_TimberReducedEnd;
-      eTS_Shoved: code := eMC_95_ReducedEndInfill;
-      eTS_Selected: code := eMC_55_ReducedEnd;
-    end;
+      case timberStatus of
+        eTS_Normal:
+          code := eMC_5_TimberReducedEnd;
+        eTS_Shoved:
+          code := eMC_95_ReducedEndInfill;
+        eTS_Selected:
+          code := eMC_55_ReducedEnd;
+      end;
 
       p1.x := xns - tbl + crab;           // draw reduced timber ends (close-dotted) ...
       p1.y := ynsred + yret;
@@ -25718,8 +25730,7 @@ begin
 
     // now timber centre-lines if there is some data...
 
-    if (pad_form.timber_centres_menu_entry.Checked) and (timbcentre_wait.valid) then
-    begin
+    if (pad_form.timber_centres_menu_entry.Checked) and (timbcentre_wait.valid) then begin
 
       with timbcentre_wait do begin
         // saved actual co-ords, to be entered in list after the outlines.
@@ -25735,20 +25746,26 @@ begin
 
       if midline then begin
         case timberStatus of
-          eTS_Normal: code := eMC_14_TimberCLMidline;
-          eTS_Shoved: code := eMC_54_ShovingTimberCLMidline;
-          eTS_Selected: code := eMC_54_ShovingTimberCLMidline;
+          eTS_Normal:
+            code := eMC_14_TimberCLMidline;
+          eTS_Shoved:
+            code := eMC_54_ShovingTimberCLMidline;
+          eTS_Selected:
+            code := eMC_54_ShovingTimberCLMidline;
         end;
       end
       else begin
         case timberStatus of
-          eTS_Normal: code := eMC_4_TimberCL;
-          eTS_Shoved: code := eMC_44_ShovingTimberCL;
-          eTS_Selected: code := eMC_44_ShovingTimberCL;
+          eTS_Normal:
+            code := eMC_4_TimberCL;
+          eTS_Shoved:
+            code := eMC_44_ShovingTimberCL;
+          eTS_Selected:
+            code := eMC_44_ShovingTimberCL;
         end;
       end;
 
-      calc_fill_timber_mark(code)
+      calc_fill_timber_mark(code);
     end;
 
     // 214a and finally do the experimental chairs...

--- a/pdf_unit.pas
+++ b/pdf_unit.pas
@@ -571,17 +571,17 @@ begin
       eMC_9_PegArm_2,
       eMC_10_PlainTrackStart:
         Result := False;
-      eMC_14_TimberCLSolid:
+      eMC_14_TimberCLMidline:
         Result := output_timbering_checkbox.Checked and
           output_timber_centres_checkbox.Checked;
-      eMC_33_ShovingTimberOutline:
+      eMC_33_SelectedTimberOutline:
         Result := output_timbering_checkbox.Checked;
-      eMC_44_ShovingTimberCL_1,
-      eMC_54_ShovingTimberCL_2:
+      eMC_44_ShovingTimberCL,
+      eMC_54_ShovingTimberCLMidline:
         Result := output_timbering_checkbox.Checked and
           output_timber_centres_checkbox.Checked;
       eMC_55_ReducedEnd,
-      eMC_93_ShovedTimberInfill,
+      eMC_93_ShovedTimberOutline,
       eMC_95_ReducedEndInfill,
       eMC_99_TimberNumber:
         Result := output_timbering_checkbox.Checked;
@@ -622,11 +622,11 @@ begin
     eMC_2_RadialEnd:
       Result := lsMark_RadialEnd;
     eMC_3_TimberOutline,
-    eMC_33_ShovingTimberOutline,
-    eMC_93_ShovedTimberInfill:
+    eMC_33_SelectedTimberOutline,
+    eMC_93_ShovedTimberOutline:
       Result := lsMark_TimberOutline;
     eMC_4_TimberCL,
-    eMC_44_ShovingTimberCL_1:
+    eMC_44_ShovingTimberCL:
       Result := lsMark_TimberCentreline;
     eMC_5_TimberReducedEnd,
     eMC_55_ReducedEnd,
@@ -636,7 +636,7 @@ begin
       Result := lsMArk_RailJoint;
     eMC_7_TransitionAndSlewing:
       Result := lsMark_Slewing;
-    eMC_14_TimberCLSolid:
+    eMC_14_TimberCLMidline:
       Result := lsMark_TimberRivetCentreline;
     eMC_600_LongMark,
     eMC_700_XingLongMark:                  // TODO: this does not seem to make sense :-/

--- a/print_unit.pas
+++ b/print_unit.pas
@@ -669,12 +669,12 @@ var
             eMC_3_TimberOutline,
             eMC_4_TimberCL,
             eMC_5_TimberReducedEnd,
-            eMC_14_TimberCLSolid,
-            eMC_33_ShovingTimberOutline,
-            eMC_44_ShovingTimberCL_1,
-            eMC_54_ShovingTimberCL_2,
+            eMC_14_TimberCLMidline,
+            eMC_33_SelectedTimberOutline,
+            eMC_44_ShovingTimberCL,
+            eMC_54_ShovingTimberCLMidline,
             eMC_55_ReducedEnd,
-            eMC_93_ShovedTimberInfill,
+            eMC_93_ShovedTimberOutline,
             eMC_95_ReducedEndInfill,
             eMC_99_TimberNumber,
             eMC_203_TimberInfill,
@@ -760,11 +760,11 @@ var
               eMC_2_RadialEnd:
                 Pen.Width := printmark_wide;    // rad end marks.
               eMC_3_TimberOutline,
-              eMC_33_ShovingTimberOutline,
-              eMC_93_ShovedTimberInfill:
+              eMC_33_SelectedTimberOutline,
+              eMC_93_ShovedTimberOutline:
                 Pen.Width := printtimber_wide;  // timber outlines.
               eMC_4_TimberCL,
-              eMC_44_ShovingTimberCL_1: begin
+              eMC_44_ShovingTimberCL: begin
                 Pen.Width := 1;
                 // timber centre-lines.
                 Pen.Style := psDash;
@@ -782,8 +782,8 @@ var
                 Pen.Width := printmark_wide;    // transition ends.
 
 
-              eMC_14_TimberCLSolid,
-              eMC_54_ShovingTimberCL_2: begin
+              eMC_14_TimberCLMidline,
+              eMC_54_ShovingTimberCLMidline: begin
                 Pen.Width := printrail_wide;
                 // timber centre-lines with rail centre-lines (for rivet locations?).
                 Pen.Style := psSolid;
@@ -819,8 +819,8 @@ var
                 eMC_2_RadialEnd:
                   Pen.Color := printalign_colour;  // rad end marks.
                 eMC_3_TimberOutline,
-                eMC_33_ShovingTimberOutline,
-                eMC_93_ShovedTimberInfill:
+                eMC_33_SelectedTimberOutline,
+                eMC_93_ShovedTimberOutline:
                   Pen.Color := printtimber_colour; // timber outlines.
                 eMC_6_RailJoint:
                   Pen.Color := printjoint_colour;  // rail joint marks.
@@ -4128,12 +4128,12 @@ begin
               eMC_3_TimberOutline,
               eMC_4_TimberCL,
               eMC_5_TimberReducedEnd,
-              eMC_14_TimberCLSolid,
-              eMC_33_ShovingTimberOutline,
-              eMC_44_ShovingTimberCL_1,
-              eMC_54_ShovingTimberCL_2,
+              eMC_14_TimberCLMidline,
+              eMC_33_SelectedTimberOutline,
+              eMC_44_ShovingTimberCL,
+              eMC_54_ShovingTimberCLMidline,
               eMC_55_ReducedEnd,
-              eMC_93_ShovedTimberInfill,
+              eMC_93_ShovedTimberOutline,
               eMC_95_ReducedEndInfill,
               eMC_99_TimberNumber,
               eMC_203_TimberInfill,
@@ -4223,11 +4223,11 @@ begin
                 eMC_2_RadialEnd:
                   Pen.Width := printmark_wide;    // rad end marks.
                 eMC_3_TimberOutline,
-                eMC_33_ShovingTimberOutline,
-                eMC_93_ShovedTimberInfill:
+                eMC_33_SelectedTimberOutline,
+                eMC_93_ShovedTimberOutline:
                   Pen.Width := printtimber_wide;  // timber outlines.
                 eMC_4_TimberCL,
-                eMC_44_ShovingTimberCL_1:
+                eMC_44_ShovingTimberCL:
                   Pen.Width := 1;                  // timber centre-lines.
                 eMC_5_TimberReducedEnd,
                 eMC_55_ReducedEnd,
@@ -4237,8 +4237,8 @@ begin
                   Pen.Width := printmark_wide;    // rail joint marks.
                 eMC_7_TransitionAndSlewing:
                   Pen.Width := printmark_wide;    // transition ends.
-                eMC_14_TimberCLSolid,
-                eMC_54_ShovingTimberCL_2:
+                eMC_14_TimberCLMidline,
+                eMC_54_ShovingTimberCLMidline:
                   Pen.Width := printrail_wide;
                 // timber centre-lines with rail centre-lines (for rivet locations?).
 
@@ -4257,7 +4257,7 @@ begin
             end;
             case code of
               eMC_4_TimberCL,
-              eMC_44_ShovingTimberCL_1:
+              eMC_44_ShovingTimberCL:
                 Pen.Style := psDash;    // timber centre-lines (not for rivets).
               eMC_5_TimberReducedEnd,
               eMC_55_ReducedEnd,
@@ -4291,8 +4291,8 @@ begin
                     eMC_2_RadialEnd:
                       Pen.Color := printalign_colour;  // rad end marks.
                     eMC_3_TimberOutline,
-                    eMC_33_ShovingTimberOutline,
-                    eMC_93_ShovedTimberInfill:
+                    eMC_33_SelectedTimberOutline,
+                    eMC_93_ShovedTimberOutline:
                       Pen.Color := printtimber_colour; // timber outlines.
                     eMC_6_RailJoint:
                       Pen.Color := printjoint_colour;  // rail joints.


### PR DESCRIPTION
This change introduces an alternative way to produce CL mark codes
without "calculating" them.

This is a step on the path of removing meaning from the actual values of the mark code enum and allowing the compiler to assign them.